### PR TITLE
Fikse back-navigering fra feil-ved-innsending

### DIFF
--- a/src/pages/feil-ved-innsending/index.tsx
+++ b/src/pages/feil-ved-innsending/index.tsx
@@ -4,8 +4,30 @@ import BannerLayout from '@/components/banner-layout/BannerLayout';
 import CustomGuidePanel from '@/components/custom-guide-panel/CustomGuidePanel';
 import styles from './FeilVedInnsending.module.css';
 import { pageWithAuthentication } from '@/utils/pageWithAuthentication';
+import defaultValues from '@/defaultValues';
+import { useRouter } from 'next/router';
+import { useFormContext } from 'react-hook-form';
+import Søknad from '@/types/Søknad';
 
 export default function FeilVedInnsending() {
+    const router = useRouter();
+    const { reset } = useFormContext<Søknad>();
+
+    React.useEffect(() => {
+        router.beforePopState(({ as }) => {
+            if (as !== router.asPath) {
+                reset(defaultValues);
+                router.push(process.env.NEXT_PUBLIC_BASE_PATH ?? '/', '', { shallow: false });
+                return false;
+            }
+            return true;
+        });
+
+        return () => {
+            router.beforePopState(() => true);
+        };
+    }, [router]);
+
     return (
         <div className={styles.feilVedInnsending}>
             <Heading size="medium" level="2" className={styles.feilVedInnsendingHeading}>


### PR DESCRIPTION
Sørger for at når man trykker Back i browser etter å ha fått feil ved innsending, blir formet resatt og bruker sendes til forsiden av søknaden (samme oppførsel som på kvitteringssiden)