### PR TITLE
Legg til feilmelding på dato frem i tid i datovelger

### DIFF
--- a/src/components/datospørsmål/Datospørsmål.tsx
+++ b/src/components/datospørsmål/Datospørsmål.tsx
@@ -9,12 +9,26 @@ import { Hjelpetekst } from '@/types/Hjelpetekst';
 interface DatospørsmålProps {
     name: string;
     children: string;
-    validate?: ValidatorFunction;
+    validate?: ValidatorFunction | ValidatorFunction[];
     minDate?: Date;
     maxDate?: Date;
     hjelpetekst?: Hjelpetekst;
     datoMåVæreIFortid?: boolean;
     legend?: string;
+}
+
+function validatorArrayAsObject(validate: ValidatorFunction[]) {
+    const validateObject: { [key: string]: ValidatorFunction } = {};
+    validate.forEach((validatorFunction, index) => (validateObject[`${index}`] = validatorFunction));
+    return validateObject;
+}
+
+
+function setupValidation(validate?: ValidatorFunction | ValidatorFunction[]) {
+    if (Array.isArray(validate)) {
+        return validatorArrayAsObject(validate);
+    }
+    return validate;
 }
 
 export default function Datospørsmål({
@@ -36,7 +50,7 @@ export default function Datospørsmål({
             <Controller
                 name={name}
                 control={control}
-                rules={{validate}}
+                rules={{ validate: setupValidation(validate) }}
                 render={({ field: { onChange, value } }) => (
                     <Datovelger
                         id={name}

--- a/src/components/datovelger/Datovelger.tsx
+++ b/src/components/datovelger/Datovelger.tsx
@@ -1,4 +1,4 @@
-import { DatePicker, useDatepicker } from '@navikt/ds-react';
+import { DatePicker, ErrorMessage, useDatepicker } from '@navikt/ds-react';
 import { useState } from 'react';
 
 interface DatovelgerProps {
@@ -11,7 +11,6 @@ interface DatovelgerProps {
     datoMåVæreIFortid?: boolean;
     defaultSelected: Date;
 }
-
 export default function Datovelger({
     onDateChange,
     errorMessage,
@@ -22,29 +21,41 @@ export default function Datovelger({
     datoMåVæreIFortid,
     defaultSelected,
 }: DatovelgerProps) {
+    const [dateError, setDateError] = useState<string>('');
+
     const { datepickerProps, inputProps } = useDatepicker({
         onDateChange,
         fromDate: minDate,
         defaultMonth: minDate,
         toDate: datoMåVæreIFortid ? new Date() : maxDate,
         defaultSelected: defaultSelected,
-        onValidate: (val) => {
-            setHasError(!val.isValidDate);
+        onValidate: (validation) => {
+            if (validation.isAfter) {
+                setDateError('Dato kan ikke være i fremtiden');
+            } else {
+                setDateError('');
+            }
         },
         openOnFocus: false,
-    });
+        });
+        
+        const computedError = dateError || errorMessage;
 
-    const [hasError, setHasError] = useState(false);
 
     return (
+        <>
+        <div style={{paddingBottom: '0.5rem'}}>
         <DatePicker {...datepickerProps} id={id}>
             <DatePicker.Input
                 {...inputProps}
                 label={label}
-                error={hasError && errorMessage}
+                error={!!computedError}
                 autoComplete="off"
                 id={id}
             />
         </DatePicker>
+        </div>
+        {computedError ? <ErrorMessage size={'medium'}>{`• ${computedError}`}</ErrorMessage> : ''}
+        </>
     );
 }

--- a/src/components/datovelger/Datovelger.tsx
+++ b/src/components/datovelger/Datovelger.tsx
@@ -1,4 +1,4 @@
-import { DatePicker, ErrorMessage, useDatepicker } from '@navikt/ds-react';
+import { DatePicker, useDatepicker } from '@navikt/ds-react';
 import { useState } from 'react';
 
 interface DatovelgerProps {
@@ -43,19 +43,14 @@ export default function Datovelger({
 
 
     return (
-        <>
-        <div style={{paddingBottom: '0.5rem'}}>
         <DatePicker {...datepickerProps} id={id}>
             <DatePicker.Input
                 {...inputProps}
                 label={label}
-                error={!!computedError}
+                error={computedError}
                 autoComplete="off"
                 id={id}
             />
         </DatePicker>
-        </div>
-        {computedError ? <ErrorMessage size={'medium'}>{`• ${computedError}`}</ErrorMessage> : ''}
-        </>
     );
 }


### PR DESCRIPTION
### Forklaring
Legger inn feilmeldingen "Dato kan ikke være i fremtiden" på manuelt innskrevet dato frem i tid i `Datovelger`. Gjør også at feilmeldingen "Du må oppgi fødselsdato" dukker opp når feltet er tomt ved lagring. Feilmeldingen ble gjort generisk ettersom feilmeldingen måtte settes direkte i komponenten for at valideringen skulle slå ut ved manuell innskriving av dato. Endringen vises derfor både i alderspensjon-spørsmålet i `AndreUtbetalingerSteg` og i `LeggTilBarnModal`.

### Visuelle endringer
![Screenshot 2023-08-22 at 15 58 55](https://github.com/navikt/tiltakspenger-soknad/assets/44436236/7db8bfb8-b393-43bc-9fef-7f16709d2372)

![Screenshot 2023-08-22 at 15 59 22](https://github.com/navikt/tiltakspenger-soknad/assets/44436236/ff69af8b-9de2-469c-8573-b4684d4fcae5)

![Screenshot 2023-08-22 at 15 59 41](https://github.com/navikt/tiltakspenger-soknad/assets/44436236/61ba6475-84fd-4758-88c3-4d4a1b5f0a08)

### Eventuelt
Feilmeldingen kan endres til mer likt format som de andre feilmeldingene, f.eks `Du må oppgi dato tilbake i tid` om det klinger bedre!

