### PR TITLE
Legg knapper ved siden av hverandre i LeggTilBarnModal og fjern unødvendig css

### DIFF
--- a/src/components/barnetillegg/Barnetillegg.module.css
+++ b/src/components/barnetillegg/Barnetillegg.module.css
@@ -11,17 +11,6 @@
     margin-top: 1rem;
 }
 
-.knappAvbrytModal{
-    width: 100%;
-    margin-top: 1rem;
-}
-
-.knappLagreModal{
-    width: 100%;
-    margin-top: 1rem;
-    margin-bottom: 1rem;
-}
-
 .modalLeggTilBarn {
     background-color: var(--a-gray-50);
     width: 100%;

--- a/src/components/barnetillegg/LeggTilBarnModal.tsx
+++ b/src/components/barnetillegg/LeggTilBarnModal.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useImperativeHandle, useRef, useState } from 'react';
 import JaNeiSpørsmål from '@/components/ja-nei-spørsmål/JaNeiSpørsmål';
 import { v4 as uuidv4 } from 'uuid';
 import styles from './Barnetillegg.module.css';
+import stepStyles from './../../components/step/Step.module.css';
 import { ExternalLinkIcon } from '@navikt/aksel-icons';
 import {
     påkrevdDatoValidator,
@@ -212,7 +213,8 @@ export const LeggTilBarnModal = React.forwardRef<LeggTilBarnModalImperativeHandl
                                 />
                             </div>
                         </div>
-                        <Button onClick={lukkModal} className={styles.knappAvbrytModal} variant="secondary">
+                        <div className={stepStyles.step__buttonsection}>
+                        <Button onClick={lukkModal} variant="secondary">
                             Avbryt
                         </Button>
                         <Button
@@ -232,11 +234,12 @@ export const LeggTilBarnModal = React.forwardRef<LeggTilBarnModalImperativeHandl
                                     setOpen(false);
                                 }
                             }}
-                            className={styles.knappLagreModal}
+                        
                             variant="primary"
                         >
                             Lagre
                         </Button>
+                        </div>
                     </Modal.Content>
                 </Modal>
             </>


### PR DESCRIPTION
### Forklaring
Legger avbryt- og lagreknappen i `LeggTilBarnModal` ved siden av hverandre i stedet for over hverandre. Fjerner også tidligere egendefinert css på disse slik at de blir likt stylet som resten av knappene i søknaden.

### Visuelle endringer
![Screenshot 2023-08-23 at 14 24 35](https://github.com/navikt/tiltakspenger-soknad/assets/44436236/c68c6244-7c17-4180-b944-6c21d3191f07)
