### PR TITLE
Fjerner redirect-kode

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,7 +19,6 @@ import IkkeMyndig from '@/components/ikke-myndig/IkkeMyndig';
 import CustomGuidePanel from '@/components/custom-guide-panel/CustomGuidePanel';
 import { pageWithAuthentication } from '@/utils/pageWithAuthentication';
 import { mockedPersonalia } from '@/mocks/mockedPersonalia';
-import { brukerSkalRedirectesTilGammelSøknad } from '@/utils/featureToggling';
 
 function harBekreftetÅSvareSåGodtManKanValidator(verdi: boolean) {
     return påkrevdBekreftelsesspørsmål(
@@ -128,23 +127,6 @@ function redirectBrukerTilGammelSøknad() {
 
 export const getServerSideProps = pageWithAuthentication(async (context: GetServerSidePropsContext) => {
     const backendUrl = process.env.TILTAKSPENGER_SOKNAD_API_URL;
-
-    if (process.env.NODE_ENV === 'production') {
-        try {
-            const skalRedirectes = await brukerSkalRedirectesTilGammelSøknad(context.req.headers.authorization!);
-            if (skalRedirectes) {
-                logger.info('Bruker redirectes til gammel søknad');
-                return redirectBrukerTilGammelSøknad();
-            }
-        } catch (error) {
-            logger.error(
-                `Noe gikk galt ved oppsett av unleash: ${
-                    (error as Error).message
-                }. Bruker redirectes til gammel søknad.`
-            );
-            return redirectBrukerTilGammelSøknad();
-        }
-    }
 
     let token = null;
     try {

--- a/src/utils/featureToggling.ts
+++ b/src/utils/featureToggling.ts
@@ -1,19 +1,8 @@
 import { evaluateFlags, flagsClient, getDefinitions, randomSessionId } from '@unleash/nextjs';
 
-function utledFødselsdatoFraToken(bearerToken: string) {
-    const jwt = bearerToken!!.replace('Bearer ', '').split('.')[1];
-    const payload = JSON.parse(Buffer.from(jwt, 'base64').toString());
-    return payload.pid.substring(0, 4);
-}
-
 export async function featureIsEnabled(featureName: string, userId = randomSessionId()) {
     const definitions = await getDefinitions();
     const { toggles } = evaluateFlags(definitions!!, { userId });
     const flags = flagsClient(toggles);
     return flags.isEnabled(featureName);
-}
-
-export async function brukerSkalRedirectesTilGammelSøknad(bearerToken: string) {
-    const fødselsdato = utledFødselsdatoFraToken(bearerToken);
-    return featureIsEnabled('REDIRECT_TIL_GAMMEL_SOKNAD', fødselsdato);
 }


### PR DESCRIPTION
Fjerner kallet på koden som har tidligere har redirectet brukere til den gamle tiltakspengesøknaden. Lar selve implementasjonen stå litt i tilfelle det blir bruk for den senere.