### PR TITLE
fjerner ubrukt journalpostid fra respons

### DIFF
--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -46,3 +46,7 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: nodejs
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki

--- a/src/types/SøknadResponse.ts
+++ b/src/types/SøknadResponse.ts
@@ -1,5 +1,4 @@
 interface SøknadResponse {
-    journalpostId: string;
     innsendingTidspunkt: string;
 }
 export default SøknadResponse;


### PR DESCRIPTION
## Beskrivelse
Fjerner journalpostid fra responsen fra backend. Denne brukes ikke til noe, og backend sender uansett bare en dummystring siden journalposten opprettes asynkront etter at søknaden er mottatt. 

## Kommentarer
<!--- Er det noe mer som bør opplyses om til den som ser over? -->

## Visuelle endringer:
<!--- Legg ved skjermbilder av de visuelle endringene dersom det er relevant -->
