### PR TITLE
1070 La lenker fra feiloppsummering flytte fokus til relevant felt

### DIFF
--- a/src/components/flervalgsspørsmål/Flervalgsspørsmål.tsx
+++ b/src/components/flervalgsspørsmål/Flervalgsspørsmål.tsx
@@ -45,6 +45,7 @@ export default function Flervalgsspørsmål({
                         afterOnChange && afterOnChange();
                     }}
                     error={errorMessage}
+                    tabIndex={-1}
                 >
                     {hjelpetekst && <ReadMore header={hjelpetekst.tittel}>{hjelpetekst.tekst}</ReadMore>}
                     {alternativer.map((alternativ) => (

--- a/src/components/ja-nei-spørsmål/JaNeiSpørsmål.tsx
+++ b/src/components/ja-nei-spørsmål/JaNeiSpørsmål.tsx
@@ -57,6 +57,7 @@ export default function JaNeiSpørsmål({
                         afterOnChange && afterOnChange();
                     }}
                     {...errorObject}
+                    tabIndex={-1}
                 >
                     {hjelpetekst && <ReadMore header={hjelpetekst.tittel}>{hjelpetekst.tekst}</ReadMore>}
                     {!reverse && <Radio value="nei">Nei</Radio>}


### PR DESCRIPTION
Setter tabIndex -1 på radiobuttongroups, hvis ikke finner ikke tastaturnavigasjonen hvor fokuset skal være og document.activeElement blir satt til <body>. Med tabIndex -1 kan elementet få fokus programmatisk som forventet når man benytter seg av lenkene fra ErrorSummary