### PR TITLE
1594 legger til gjennomføringsid for tiltak

### DIFF
--- a/src/mocks/mockedTiltak.ts
+++ b/src/mocks/mockedTiltak.ts
@@ -5,7 +5,7 @@ export const mocketTiltak = [
         typeNavn: 'Annen utdanning',
         arenaRegistrertPeriode: {},
         arrangør: 'Testarrangør',
-        status: 'Aktuell',
+        gjennomforingId: '123456',
     },
     {
         aktivitetId: '12asdad3',
@@ -13,7 +13,7 @@ export const mocketTiltak = [
         typeNavn: 'Annen utdaasdnning',
         arenaRegistrertPeriode: {},
         arrangør: 'Testarrangør',
-        status: 'Aktuell',
+        gjennomforingId: '98765',
     },
     {
         aktivitetId: '12sdf3',
@@ -21,6 +21,6 @@ export const mocketTiltak = [
         typeNavn: 'Annen utdweranning',
         arenaRegistrertPeriode: { fra: '2025-04-01', til: '2026-03-01' },
         arrangør: 'Testarrangør',
-        status: 'Aktuell',
+        gjennomforingId: '456788',
     },
 ] as const;

--- a/src/types/Tiltak.ts
+++ b/src/types/Tiltak.ts
@@ -6,5 +6,5 @@ export interface Tiltak {
     typeNavn: string;
     arenaRegistrertPeriode?: Periode;
     arrangør: string;
-    status: string;
+    gjennomforingId: string;
 }

--- a/src/utils/toSøknadJson.ts
+++ b/src/utils/toSøknadJson.ts
@@ -113,6 +113,7 @@ function tiltak(formTiltak: FormTiltak, tiltak: Tiltak) {
         typeNavn: tiltak.typeNavn,
         arenaRegistrertPeriode: tiltak.arenaRegistrertPeriode,
         periode: formatPeriod(formTiltak.periode!),
+        gjennomforingId: tiltak.gjennomforingId,
     };
 }
 


### PR DESCRIPTION
Fjernet også status som ikke var i bruk. 

https://trello.com/c/oenlCprg/1594-legge-til-rette-for-at-vi-kan-ta-inn-alle-deltakere-p%C3%A5-en-gjennomf%C3%B8ring-i-v%C3%A5r-l%C3%B8sning