### PR TITLE
ci: pin nais/docker-build-push til SHA (# v0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/.build-app.yml
+++ b/.github/workflows/.build-app.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Build and push docker image
         # Versjonsoversikt (tag -> SHA): https://github.com/nais/docker-build-push/tags
+        # Denne SHA-en: https://github.com/nais/docker-build-push/commit/31c3a7321909bcb20799fdf46153fec721fd9512
         uses: nais/docker-build-push@31c3a7321909bcb20799fdf46153fec721fd9512 # v0
         if: inputs.buildImage == true
         id: docker-push

--- a/.github/workflows/.build-app.yml
+++ b/.github/workflows/.build-app.yml
@@ -59,7 +59,8 @@ jobs:
         run: npm run build
 
       - name: Build and push docker image
-        uses: nais/docker-build-push@v0
+        # Versjonsoversikt (tag -> SHA): https://github.com/nais/docker-build-push/tags
+        uses: nais/docker-build-push@31c3a7321909bcb20799fdf46153fec721fd9512 # v0
         if: inputs.buildImage == true
         id: docker-push
         with:


### PR DESCRIPTION
## Hva
Pinner `nais/docker-build-push` fra den bevegelige `@v0`-taggen til en immutable SHA-referanse, med `# v0`-kommentar og lenker til både versjonsoversikten og den faktiske commit-en rett over:

```yaml
# Versjonsoversikt (tag -> SHA): https://github.com/nais/docker-build-push/tags
# Denne SHA-en: https://github.com/nais/docker-build-push/commit/31c3a7321909bcb20799fdf46153fec721fd9512
uses: nais/docker-build-push@31c3a7321909bcb20799fdf46153fec721fd9512 # v0
```

## Hvorfor
- `v0` er en **major-tag som overskrives** ved hver release, altså ikke immutable eller sporbar.
- SHA-pinning gir en fast, verifiserbar action-referanse (supply chain / SLSA best practice, jf. [nais/docker-build-push](https://github.com/nais/docker-build-push)).
- **Dependabot** leser `# v0`-kommentaren og bumper SHA-en videre automatisk når `v0` flyttes.
- Kommentarene over linja gjør det lett for utviklere å slå opp hvilken versjon en SHA tilsvarer. Siden taggen alltid er `v0`, peker vi også direkte på commit-en SHA-en er pinnet til, så man ser den faktiske releasen.

Del av utrulling på tvers av tpts-repoene.I tillegg legges `github-actions` til i `.github/dependabot.yml` (repoet hadde kun `npm`), slik at SHA-en holdes oppdatert automatisk.